### PR TITLE
Install google chrome by default

### DIFF
--- a/files/scripts/common/disableRepos.sh
+++ b/files/scripts/common/disableRepos.sh
@@ -3,5 +3,6 @@
 set -eoux pipefail
 
 dnf config-manager setopt fedora-cisco-openh264.enabled=0
+dnf config-manager setopt google-chrome.enabled=0
 
 dnf config-manager setopt copr:copr.fedorainfracloud.org:atim:ubuntu-fonts.enabled=0

--- a/files/scripts/common/enableGoogleChromeRepo.sh
+++ b/files/scripts/common/enableGoogleChromeRepo.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# from https://github.com/rrenomeron/ublue-tr
+
+set -oue pipefail
+# Part of an attempt to add Google Chrome in the usual way.
+echo "Fixing google-chrome yum repo"
+sed -i '/enabled/d' /etc/yum.repos.d/google-chrome.repo
+echo "enabled=1" >> /etc/yum.repos.d/google-chrome.repo
+
+# This does not appear to be necessary, since at this point there are no
+# Google keys in the RPM database.  Will be deleted soon.
+
+# First, delete all old keys; see https://github.com/rpm-software-management/rpm/issues/2577
+# echo "Fixing issues with Google GPG keys"
+# set +oue
+# rpm -qa gpg-pubkey* --qf '%{NAME}-%{VERSION}-%{RELEASE} %{PACKAGER}\n' | grep 'linux-packages-keymaster@google.com' | sed 's/ .*$//' | xargs
+# GOOGLE_PUBKEYS_RPMS=$(rpm -qa gpg-pubkey* --qf '%{NAME}-%{VERSION}-%{RELEASE} %{PACKAGER}\n' | grep 'linux-packages-keymaster@google.com' | sed 's/ .*$//' | xargs)
+# set -oue
+# echo "Installed pubkeys RPMS are $GOOGLE_PUBKEYS_RPMS"
+# if [ -n "$GOOGLE_PUBKEYS_RPMS" ]; then
+#     echo "Removing pakcages $GOOGLE_PUBKEYS_RPMS"
+#     rpm -e $GOOGLE_PUBKEYS_RPMS
+# fi
+
+# We need to download and install the Google signing keys separately, we can't trust
+# rpm-ostree to do it cleanly from the yum repo directly.
+# Possibly related to https://github.com/rpm-software-management/rpm/issues/2577
+
+echo "Downloading Google Signing Key"
+curl https://dl.google.com/linux/linux_signing_key.pub > /tmp/linux_signing_key.pub
+
+rpm --import /tmp/linux_signing_key.pub
+
+rm /tmp/linux_signing_key.pub

--- a/recipes/common/common-rpm.yml
+++ b/recipes/common/common-rpm.yml
@@ -1,6 +1,10 @@
 # yaml-language-server: $schema=https://schema.blue-build.org/module-stage-list-v1.json
 
 modules:
+  - type: script
+    scripts:
+      - common/enableGoogleChromeRepo.sh
+
   - type: rpm-ostree
     repos:
       - https://copr.fedorainfracloud.org/coprs/atim/ubuntu-fonts/repo/fedora-%OS_VERSION%/atim-ubuntu-fonts-fedora-%OS_VERSION%.repo
@@ -16,7 +20,10 @@ modules:
       - fira-code-fonts
       - cascadia-code-nf-fonts
       - java-17-openjdk
+      - google-chrome-stable
       - https://downloads.sourceforge.net/project/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm
+    optfix:
+      - google
     remove:
       # example: removing firefox (in favor of the flatpak)
       # "firefox" is the main package, "firefox-langpacks" is a dependency


### PR DESCRIPTION
Add rpm google chrome to the images.
Main reason is because the integration between autofirma and google chrome works fine (just as in firefox on the other hand), but it would be nice to have 2 fully functional browsers as the DNIE integration is a bit finicky sometimes.