### PR TITLE
Change some default flatpaks following Bluefin's changes in preparation for F42

### DIFF
--- a/recipes/common/common-rpm.yml
+++ b/recipes/common/common-rpm.yml
@@ -13,8 +13,6 @@ modules:
       - gnome-shell-extension-appindicator
       # all evince related libraries are already installed, don't see the benefit on installing it via flatpak
       - evince
-      # *I think* flatpak simple-scan only works with driverless scanners, probably better to keep it layered
-      - simple-scan
       # additional fonts
       - ubuntu-family-fonts
       - fira-code-fonts

--- a/recipes/dev/dev-flatpak.yml
+++ b/recipes/dev/dev-flatpak.yml
@@ -20,6 +20,8 @@ modules:
         - org.gnome.Contacts
         - org.gnome.Logs
         - org.gnome.Loupe
-        - org.gnome.TextEditor
+        - org.gnome.SimpleScan
         - org.gnome.Showtime
+        - org.gnome.TextEditor
         - org.libreoffice.LibreOffice
+        - page.tesk.Refine

--- a/recipes/home/home-flatpak.yml
+++ b/recipes/home/home-flatpak.yml
@@ -20,7 +20,9 @@ modules:
         - org.gnome.Contacts
         - org.gnome.Logs
         - org.gnome.Loupe
-        - org.gnome.TextEditor
+        - org.gnome.SimpleScan
         - org.gnome.Showtime
+        - org.gnome.TextEditor
         - org.libreoffice.LibreOffice
-        - com.github.maoschanz.drawing
+        - com.github.PintaProject.Pinta
+        - page.tesk.Refine


### PR DESCRIPTION
- SimpleScan installed as flatpak instead of system package
- Pinta instead of Drawing as it's more complete
- Refine as flatpak as Ublue will remove gnome-tweaks by default