### PR TITLE
Switching dev and dev-nvidia to Fedora 42

### DIFF
--- a/recipes/common/common-rpm.yml
+++ b/recipes/common/common-rpm.yml
@@ -17,7 +17,6 @@ modules:
       - ubuntu-family-fonts
       - fira-code-fonts
       - cascadia-code-nf-fonts
-      - java-17-openjdk
       - google-chrome-stable
       - https://downloads.sourceforge.net/project/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm
     optfix:

--- a/recipes/dev/dev-rpm.yml
+++ b/recipes/dev/dev-rpm.yml
@@ -17,3 +17,4 @@ modules:
       - tailscale
       - wireguard-tools
       - gnome-shell-extension-tailscale-gnome-qs
+      - java-21-openjdk

--- a/recipes/home/home-rpm.yml
+++ b/recipes/home/home-rpm.yml
@@ -3,5 +3,6 @@ modules:
 
   - type: rpm-ostree
     install:
+      - java-17-openjdk
       - gnome-shell-extension-dash-to-panel
       - gnome-shell-extension-blur-my-shell

--- a/recipes/recipe-dev-nvidia.yml
+++ b/recipes/recipe-dev-nvidia.yml
@@ -7,7 +7,7 @@ description: This is my personal OS image with nvidia drivers.
 
 # the base image to build on top of (FROM) and the version tag to use
 base-image: ghcr.io/ublue-os/silverblue-nvidia
-image-version: 41 # latest is also supported if you want new updates ASAP
+image-version: 42 # latest is also supported if you want new updates ASAP
 
 # module configuration, executed in order
 # you can include multiple instances of the same module

--- a/recipes/recipe-dev.yml
+++ b/recipes/recipe-dev.yml
@@ -7,7 +7,7 @@ description: This is my personal OS image.
 
 # the base image to build on top of (FROM) and the version tag to use
 base-image: ghcr.io/ublue-os/silverblue-main
-image-version: 41 # latest is also supported if you want new updates ASAP
+image-version: 42 # latest is also supported if you want new updates ASAP
 
 # module configuration, executed in order
 # you can include multiple instances of the same module


### PR DESCRIPTION
Switching dev and dev-nvidia to Fedora 42.
Java had to be changed to 21 for these images.