### PR TITLE
chore: do not disable flatpak-add-fedora-repos.service anymore

### DIFF
--- a/recipes/base-dev-recipe.yml
+++ b/recipes/base-dev-recipe.yml
@@ -24,7 +24,6 @@ modules:
         - tailscaled.service
       disabled:
         - NetworkManager-wait-online.service
-        - flatpak-add-fedora-repos.service
         - rpm-ostreed-automatic.timer
 
   - type: chezmoi

--- a/recipes/recipe-home.yml
+++ b/recipes/recipe-home.yml
@@ -29,7 +29,6 @@ modules:
         - bootc-fetch-apply-updates.timer
       disabled:
         - NetworkManager-wait-online.service
-        - flatpak-add-fedora-repos.service
         - rpm-ostreed-automatic.timer
 
   - from-file: common/autofirma.yml


### PR DESCRIPTION
 do not disable flatpak-add-fedora-repos.service as ublue is taking care of not including Fedora's flatpaks by default